### PR TITLE
[FIX] Fixing errors raised by Synopsys Design Compiler

### DIFF
--- a/rtl/software_interface/rv_iommu_msi_ig.sv
+++ b/rtl/software_interface/rv_iommu_msi_ig.sv
@@ -204,10 +204,9 @@ module rv_iommu_msi_ig #(
 
             // Write MSI to the corresponding address
             WRITE: begin
-                case (wr_state_q)
 
                     // Send request to AW Channel
-                    AW_REQ: begin
+                    if (wr_state_q == AW_REQ) begin
                         mem_req_o.aw_valid  = 1'b1;
 
                         if (mem_resp_i.aw_ready) begin
@@ -215,8 +214,8 @@ module rv_iommu_msi_ig #(
                         end
                     end
 
+                    else if (wr_state_q == W_DATA) begin
                     // Send data through W channel
-                    W_DATA: begin
                         mem_req_o.w_valid   = 1'b1;
                         mem_req_o.w.last    = 1'b1;
 
@@ -226,9 +225,9 @@ module rv_iommu_msi_ig #(
                     end
 
                     // Check response code
-                    B_RESP: begin
-                        if (mem_resp_i.b_valid) begin
-                            
+                    else if (wr_state_q == B_RESP) begin
+                       if (mem_resp_i.b_valid) begin
+
                             mem_req_o.b_ready   = 1'b1;
                             state_n             = IDLE;
                             wr_state_n  = AW_REQ;
@@ -241,9 +240,8 @@ module rv_iommu_msi_ig #(
                             end
                         end
                     end
-
-                    default: state_n = IDLE;
-                endcase
+                    else
+                        state_n = IDLE;
             end
 
             // We may receive an AXI or access error when writing

--- a/rtl/translation_logic/rv_iommu_msiptw.sv
+++ b/rtl/translation_logic/rv_iommu_msiptw.sv
@@ -399,18 +399,19 @@ module rv_iommu_msiptw #(
     end : flat_seq
 
     //# MSI-MRIF
-    generate
 
+    // States
+    typedef enum logic[1:0] {
+       MRIF_PTE,         // 00
+       NOTICE_PTE,       // 01
+       MRIF_ERROR        // 10
+    } state_mrif_t;
+
+    state_mrif_t mrif_state_q, mrif_state_n;
+
+    generate
     // MRIF support enabled
     if (MSITrans == rv_iommu::MSI_FLAT_MRIF) begin : gen_mrif_support
-
-        // States
-        typedef enum logic[1:0] {
-            MRIF_PTE,         // 00
-            NOTICE_PTE,       // 01
-            MRIF_ERROR        // 10
-        } state_mrif_t;
-        state_mrif_t mrif_state_q, mrif_state_n;
 
         // Read ports
         rv_iommu::msi_pte_mrif_t msi_pte_mrif;


### PR DESCRIPTION
- The nested case statement raised internal assertion failures within Synopsys. I replaced the inner statement with an else if chain.
- The definition of a typedef within a generate statement in the MSI_PTW module seem to be non correct. I just moved the definition outside the scope of the generate statement.