### PR TITLE
[RTL] Fixes for unused and undriven RTL signals

### DIFF
--- a/rtl/software_interface/regmap/rv_iommu_regmap.sv
+++ b/rtl/software_interface/regmap/rv_iommu_regmap.sv
@@ -69,7 +69,6 @@ module rv_iommu_regmap #(
   logic [STRB_WIDTH-1:0] 	reg_be;
   logic [DATA_WIDTH-1:0]  reg_rdata;
   logic           			  reg_error;
-  logic           			  reg_ready;
 
   logic addrmiss;
   logic [215:0] wr_err;
@@ -3006,8 +3005,8 @@ module rv_iommu_regmap #(
 
       assign tr_req_iova_vpn_l_we = 1'b0;
       assign tr_req_iova_vpn_l_wd = '0;
-      assign tr_req_iova_vpn_l_we = 1'b0;
-      assign tr_req_iova_vpn_l_wd = '0;
+      assign tr_req_iova_vpn_h_we = 1'b0;
+      assign tr_req_iova_vpn_h_wd = '0;
       assign tr_req_ctl_go_we = 1'b0;
       assign tr_req_ctl_go_wd = '0;
       assign tr_req_ctl_priv_we = 1'b0;

--- a/rtl/translation_logic/cdw/rv_iommu_cdw.sv
+++ b/rtl/translation_logic/cdw/rv_iommu_cdw.sv
@@ -617,6 +617,8 @@ module rv_iommu_cdw #(
             assign up_dc_content.ta         = dc_ta_q;
             assign up_dc_content.fsc        = dc_fsc_q;
 
+            assign msi_check_error     = 1'b0;
+
         end : gen_msi_support_disabled
     endgenerate
 

--- a/rtl/translation_logic/cdw/rv_iommu_cdw_pc.sv
+++ b/rtl/translation_logic/cdw/rv_iommu_cdw_pc.sv
@@ -841,6 +841,9 @@ module rv_iommu_cdw_pc #(
             assign up_dc_content.ta         = dc_ta_q;
             assign up_dc_content.fsc        = dc_fsc_q;
                         
+            assign msi_check_error     = 1'b0;
+            assign translate_pdtp      = 1'b0;
+
         end : gen_msi_support_disabled
     endgenerate
 

--- a/rtl/translation_logic/rv_iommu_mrif_handler.sv
+++ b/rtl/translation_logic/rv_iommu_mrif_handler.sv
@@ -383,6 +383,8 @@ module rv_iommu_mrif_handler #(
             mrif_ip_q       <= '0;
             mrif_ie_q       <= '0;
             int_id_q        <= '0;
+            notice_ppn_q    <= '0;
+            notice_nid_q    <= '0;
         end 
         
         else begin

--- a/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4.sv
@@ -935,7 +935,6 @@ module rv_iommu_tw_sv39x4 #(
     //# Error routing
     always_comb begin : error_routing
 
-        cause_code_o    = '0;
         trans_error_o   = ((wrap_error)         |
                            (cdw_error)          |
                            (ptw_error)          |
@@ -950,6 +949,7 @@ module rv_iommu_tw_sv39x4 #(
             msiptw_error:       cause_code_o = msiptw_cause_code;
             mrif_handler_error: cause_code_o = mrif_handler_cause_code;
             msi_write_error_i:  cause_code_o = rv_iommu::MSI_ST_ACCESS_FAULT;
+            default:            cause_code_o = '0;
         endcase
     end : error_routing
 

--- a/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4.sv
@@ -544,6 +544,7 @@ module rv_iommu_tw_sv39x4 #(
 
         assign msiptw_axi_req_o     = '0;
 
+        assign msiptw_active        = 1'b0;
         assign msiptw_ignore        = 1'b0;
 
         assign msi_up_vpn           = '0;

--- a/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4_pc.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4_pc.sv
@@ -1070,7 +1070,6 @@ module rv_iommu_tw_sv39x4_pc #(
     //# Error routing
     always_comb begin : error_routing
 
-        cause_code_o    = '0;
         trans_error_o   =  ((wrap_error)         |
                            (cdw_error)          |
                            (ptw_error)          |
@@ -1085,6 +1084,7 @@ module rv_iommu_tw_sv39x4_pc #(
             msiptw_error:       cause_code_o = msiptw_cause_code;
             mrif_handler_error: cause_code_o = mrif_handler_cause_code;
             msi_write_error_i:  cause_code_o = rv_iommu::MSI_ST_ACCESS_FAULT;
+            default:            cause_code_o = '0;
         endcase
     end : error_routing
 

--- a/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4_pc.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4_pc.sv
@@ -622,6 +622,7 @@ module rv_iommu_tw_sv39x4_pc #(
         
         assign msiptw_axi_req_o     = '0;
 
+        assign msiptw_active        = 1'b0;
         assign msiptw_ignore        = 1'b0;
 
         assign msi_up_vpn           = '0;


### PR DESCRIPTION
## Description
This PR has the fixes for unused, undrived and uninitialized RTL signals and a fix for unique case voilation.

### Changes

- Removed unused signal `reg_ready` from _rv_iommu_regmap.sv_ since the corresponding signal in register interface `reg_intf_rsp.ready` is hard-wired to 1.
- Removed multi-driven signals `tr_req_iova_vpn_l_we` and `tr_req_iova_vpn_l_wd` in _rv_iommu_regmap.sv_.
- Initialized registers `notice_ppn_q` and `notice_nid_q` at reset state in _rv_iommu_mrif_handler.sv_.
- Fixed unique case violation "_Every case item expression was false_" in _error_routing_ block by adding a default statement.
- Fixed unassigned signals `msi_check_error`, `translate_pdtp` and `msiptw_active` when MSI transactions are disabled.

### Contributors
@maarij-10xe @faayez-10xe