### PR TITLE
fpga: Change default burst for xilinx ips

### DIFF
--- a/rtl/software_interface/rv_iommu_cq_handler.sv
+++ b/rtl/software_interface/rv_iommu_cq_handler.sv
@@ -149,7 +149,7 @@ module rv_iommu_cq_handler #(
         mem_req_o.aw.addr       = {{riscv::XLEN-riscv::PLEN{1'b0}}, cq_pptr_q};
         mem_req_o.aw.len        = 8'b0;
         mem_req_o.aw.size       = 3'b010;
-        mem_req_o.aw.burst      = axi_pkg::BURST_FIXED;
+        mem_req_o.aw.burst      = axi_pkg::BURST_INCR;
         mem_req_o.aw.lock       = '0;
         mem_req_o.aw.cache      = '0;
         mem_req_o.aw.prot       = '0;

--- a/rtl/software_interface/rv_iommu_fq_handler.sv
+++ b/rtl/software_interface/rv_iommu_fq_handler.sv
@@ -221,7 +221,7 @@ module rv_iommu_fq_handler #(
         mem_req_o.ar.addr       = '0;                   // IOMMU never reads from FQ
         mem_req_o.ar.len        = '0;
         mem_req_o.ar.size       = 3'b011;
-        mem_req_o.ar.burst      = axi_pkg::BURST_FIXED;
+        mem_req_o.ar.burst      = axi_pkg::BURST_INCR;
         mem_req_o.ar.lock       = '0;
         mem_req_o.ar.cache      = '0;
         mem_req_o.ar.prot       = '0;

--- a/rtl/software_interface/rv_iommu_msi_ig.sv
+++ b/rtl/software_interface/rv_iommu_msi_ig.sv
@@ -104,7 +104,7 @@ module rv_iommu_msi_ig #(
         mem_req_o.aw.addr       = {{riscv::XLEN-riscv::PLEN{1'b0}}, msi_addr_x_i[intv_q], 2'b0};
         mem_req_o.aw.len        = 8'd0;         // MSI writes only 32 bits
         mem_req_o.aw.size       = 3'b010;       // 4-bytes beat
-        mem_req_o.aw.burst      = axi_pkg::BURST_FIXED;
+        mem_req_o.aw.burst      = axi_pkg::BURST_INCR;
         mem_req_o.aw.lock       = '0;
         mem_req_o.aw.cache      = '0;
         mem_req_o.aw.prot       = '0;
@@ -131,7 +131,7 @@ module rv_iommu_msi_ig #(
         mem_req_o.ar.addr       = '0;                   // we never read here
         mem_req_o.ar.len        = '0;
         mem_req_o.ar.size       = 3'b011;
-        mem_req_o.ar.burst      = axi_pkg::BURST_FIXED;
+        mem_req_o.ar.burst      = axi_pkg::BURST_INCR;
         mem_req_o.ar.lock       = '0;
         mem_req_o.ar.cache      = '0;
         mem_req_o.ar.prot       = '0;

--- a/rtl/translation_logic/ptw/rv_iommu_ptw_sv39x4.sv
+++ b/rtl/translation_logic/ptw/rv_iommu_ptw_sv39x4.sv
@@ -259,7 +259,7 @@ module rv_iommu_ptw_sv39x4 #(
         mem_req_o.aw.addr       = '0;           // Physical address to access
         mem_req_o.aw.len        = 8'b0;                 // 1 beat per burst only
         mem_req_o.aw.size       = 3'b011;               // 64 bits (8 bytes) per beat
-        mem_req_o.aw.burst      = axi_pkg::BURST_FIXED; // Fixed start address
+        mem_req_o.aw.burst      = axi_pkg::BURST_INCR; // Fixed start address
         mem_req_o.aw.lock       = '0;
         mem_req_o.aw.cache      = '0;
         mem_req_o.aw.prot       = '0;
@@ -286,7 +286,7 @@ module rv_iommu_ptw_sv39x4 #(
         mem_req_o.ar.addr       = {{riscv::XLEN-riscv::PLEN{1'b0}}, ptw_pptr_q};           // Physical address to access
         mem_req_o.ar.len        = 8'b0;                 // 1 beat per burst only
         mem_req_o.ar.size       = 3'b011;               // 64 bits (8 bytes) per beat
-        mem_req_o.ar.burst      = axi_pkg::BURST_FIXED; // Fixed start address
+        mem_req_o.ar.burst      = axi_pkg::BURST_INCR; // Fixed start address
         mem_req_o.ar.lock       = '0;
         mem_req_o.ar.cache      = '0;
         mem_req_o.ar.prot       = '0;

--- a/rtl/translation_logic/ptw/rv_iommu_ptw_sv39x4_pc.sv
+++ b/rtl/translation_logic/ptw/rv_iommu_ptw_sv39x4_pc.sv
@@ -269,7 +269,7 @@ module rv_iommu_ptw_sv39x4_pc #(
         mem_req_o.aw.addr       = '0;                   // Physical address to access
         mem_req_o.aw.len        = 8'b0;                 // 1 beat per burst only
         mem_req_o.aw.size       = 3'b011;               // 64 bits (8 bytes) per beat
-        mem_req_o.aw.burst      = axi_pkg::BURST_FIXED; // Fixed start address
+        mem_req_o.aw.burst      = axi_pkg::BURST_INCR; // Fixed start address
         mem_req_o.aw.lock       = '0;
         mem_req_o.aw.cache      = '0;
         mem_req_o.aw.prot       = '0;
@@ -296,7 +296,7 @@ module rv_iommu_ptw_sv39x4_pc #(
         mem_req_o.ar.addr       = {{riscv::XLEN-riscv::PLEN{1'b0}}, ptw_pptr_q};    // Physical address to access
         mem_req_o.ar.len        = 8'b0;                                             // 1 beat per burst only
         mem_req_o.ar.size       = 3'b011;                                           // 64 bits (8 bytes) per beat
-        mem_req_o.ar.burst      = axi_pkg::BURST_FIXED;                             // Fixed start address
+        mem_req_o.ar.burst      = axi_pkg::BURST_INCR;                             // Fixed start address
         mem_req_o.ar.lock       = '0;
         mem_req_o.ar.cache      = '0;
         mem_req_o.ar.prot       = '0;


### PR DESCRIPTION
When using certain Xilinx IPs, the burst type FIXED is not supported. In practice, they are not used (len=0) anyways.

AXI SmartConnect product guide (PG247):
> SmartConnect does not support FIXED type bursts. Any FIXED burst transaction received at the SmartConnect SI is blocked and a DECERR response is returned to the master.