### PR TITLE
dc_ext_t: Reduce size of dc_ext_t from 64B to 56B

### DIFF
--- a/packages/rv_iommu/rv_iommu_pkg.sv
+++ b/packages/rv_iommu/rv_iommu_pkg.sv
@@ -146,7 +146,6 @@ package rv_iommu;
     
     // Extended format Device Context
     typedef struct packed {
-        logic [63:0]        reserved;
         msi_addr_pattern_t  msi_addr_pattern;
         msi_addr_mask_t     msi_addr_mask;
         msiptp_t            msiptp;

--- a/rtl/translation_logic/cdw/rv_iommu_cdw.sv
+++ b/rtl/translation_logic/cdw/rv_iommu_cdw.sv
@@ -545,7 +545,6 @@ module rv_iommu_cdw #(
                 up_dc_content.msi_addr_pattern  = dc_msi_addr_patt_q;
                 up_dc_content.msi_addr_mask     = dc_msi_addr_mask_q;
                 up_dc_content.msiptp            = dc_msiptp_q;
-                up_dc_content.reserved          = '0;
 
                 // Outputs
                 up_dc_content_o = up_dc_content;

--- a/rtl/translation_logic/cdw/rv_iommu_cdw_pc.sv
+++ b/rtl/translation_logic/cdw/rv_iommu_cdw_pc.sv
@@ -763,7 +763,6 @@ module rv_iommu_cdw_pc #(
                 up_dc_content.msi_addr_pattern  = dc_msi_addr_patt_q;
                 up_dc_content.msi_addr_mask     = dc_msi_addr_mask_q;
                 up_dc_content.msiptp            = dc_msiptp_q;
-                up_dc_content.reserved          = '0;
 
                 // Outputs
                 up_dc_content_o = up_dc_content;


### PR DESCRIPTION
The reserved field of dc_ext_t is useless, because ar_len & cdw_pptr_n do not require it for context directory walk. But it would increase the size of DDTC by about DDTC_ENTRIES*8 Bytes. So, this patch removes it.

Signedeoff-by: Guo Ren (Alibaba DAMO Academy) <guoren@kernel.org>