### PR TITLE
riscv_iommu: capture complete AXI writes before MRIF processing

### DIFF
--- a/rtl/riscv_iommu.sv
+++ b/rtl/riscv_iommu.sv
@@ -110,8 +110,25 @@ module riscv_iommu #(
     enum logic [1:0] {
         IDLE,
         READ,
-        WRITE
+        WRITE,
+        WRITE_DATA
     } request_type_q, request_type_n;
+
+    // The translation request interface processes one write at a time. Keep
+    // its address metadata and data beat until both independent AXI channels
+    // have completed. MRIF handling may consume the data after AW has retired.
+    aw_chan_t                      write_aw_q;
+    w_chan_t                       write_data_q;
+    logic [23:0]                   write_did_q;
+    logic                          write_pv_q;
+    logic [19:0]                   write_pid_q;
+    logic                          write_data_valid_q;
+    logic                          write_data_complete_q, write_data_complete_n;
+    logic                          write_is_mrif_q, write_is_mrif_n;
+    logic                          write_data_handshake;
+    logic                          mrif_handler_expected;
+    logic                          mrif_data_consumed;
+    logic                          translation_request_active;
 
     // Transaction parameters
     // Final parameters. Selected between AR/AW requests and DBG IF requests
@@ -242,22 +259,29 @@ module riscv_iommu #(
     // AW
     assign axi_aux_req.aw_valid     = resume_aw_q;
 
-    assign axi_aux_req.aw.id        = dev_tr_req_i.aw.id;
+    assign axi_aux_req.aw.id        = write_aw_q.id;
     assign axi_aux_req.aw.addr      = {{riscv::XLEN-riscv::PLEN{1'b0}}, spaddr};    // translated address
-    assign axi_aux_req.aw.len       = dev_tr_req_i.aw.len;
-    assign axi_aux_req.aw.size      = dev_tr_req_i.aw.size;
-    assign axi_aux_req.aw.burst     = dev_tr_req_i.aw.burst;
-    assign axi_aux_req.aw.lock      = dev_tr_req_i.aw.lock;
-    assign axi_aux_req.aw.cache     = dev_tr_req_i.aw.cache;
-    assign axi_aux_req.aw.prot      = dev_tr_req_i.aw.prot;
-    assign axi_aux_req.aw.qos       = dev_tr_req_i.aw.qos;
-    assign axi_aux_req.aw.region    = dev_tr_req_i.aw.region;
-    assign axi_aux_req.aw.atop      = dev_tr_req_i.aw.atop;
-    assign axi_aux_req.aw.user      = dev_tr_req_i.aw.user;
+    assign axi_aux_req.aw.len       = write_aw_q.len;
+    assign axi_aux_req.aw.size      = write_aw_q.size;
+    assign axi_aux_req.aw.burst     = write_aw_q.burst;
+    assign axi_aux_req.aw.lock      = write_aw_q.lock;
+    assign axi_aux_req.aw.cache     = write_aw_q.cache;
+    assign axi_aux_req.aw.prot      = write_aw_q.prot;
+    assign axi_aux_req.aw.qos       = write_aw_q.qos;
+    assign axi_aux_req.aw.region    = write_aw_q.region;
+    assign axi_aux_req.aw.atop      = write_aw_q.atop;
+    assign axi_aux_req.aw.user      = write_aw_q.user;
 
     // W
     assign axi_aux_req.w            = dev_tr_req_i.w;
     assign axi_aux_req.w_valid      = dev_tr_req_i.w_valid;
+    assign write_data_handshake     = dev_tr_req_i.w_valid & dev_tr_resp_o.w_ready;
+
+    // These are the validity checks already implemented by the upstream MRIF
+    // path. The follow-up encoding patch extends this predicate with the AXI
+    // size and byte-lane requirements.
+    assign mrif_handler_expected    = (write_aw_q.addr[11:0] == '0) &
+                                      !(|write_data_q.data[31:11]);
 
     // B
     assign axi_aux_req.b_ready      = dev_tr_req_i.b_ready;
@@ -564,8 +588,10 @@ module riscv_iommu #(
 
         // MRIF Control
         .ignore_request_o   (ignore_request             ),  // Ignore AXI request, as the transaction was to an MRIF
-        .msi_data_valid_i   (dev_tr_req_i.w_valid       ),  // Data present in AWDATA is valid (for MRIF purposes)
-        .msi_data_i         (dev_tr_req_i.w.data[31:0]  )   // MSI data
+        .mrif_data_consumed_o(mrif_data_consumed        ),
+        .msi_data_valid_i   ((request_type_q == WRITE_DATA) & write_is_mrif_q &
+                             write_data_valid_q & mrif_handler_expected),
+        .msi_data_i         (write_data_q.data[31:0]    )   // Captured MSI data
     );
 
     //# Software Interface Wrapper
@@ -664,6 +690,10 @@ module riscv_iommu #(
     );
 
     //# Boundary Check
+    assign translation_request_active = (request_type_q == READ) |
+                                        (request_type_q == WRITE) |
+                                        ((request_type_q == WRITE_DATA) & write_is_mrif_q);
+
     // In order to send error response, we need to set the corresponding valid signal and select the error slave in the AXI Demux.
     // To do that, we may OR the translation error flag from the translation wrapper with another flag to indicate a 4kiB cross
     // and trigger the error response
@@ -673,7 +703,7 @@ module riscv_iommu #(
         rv_iommu_axi4_bc i_rv_iommu_axi4_bc
         (
             // AxVALID
-            .request_i          (request_type_q != IDLE),
+            .request_i          (translation_request_active),
             // AxADDR
             .addr_i             ( trans_iova            ),
             // AxBURST
@@ -693,7 +723,7 @@ module riscv_iommu #(
     // In this scenario, there's no need to include this logic.
     else begin : gen_axi4_bc_disabled
 
-        assign request_ongoing   = (request_type_q != IDLE);
+        assign request_ongoing = translation_request_active;
         assign bound_violation = 1'b0;
     end : gen_axi4_bc_disabled
     endgenerate
@@ -828,6 +858,9 @@ module riscv_iommu #(
         demux_ar_select_n   = demux_ar_select_q;
         resume_aw_n         = resume_aw_q;
         resume_ar_n         = resume_ar_q;
+        write_data_complete_n = write_data_complete_q |
+                                (write_data_handshake & dev_tr_req_i.w.last);
+        write_is_mrif_n       = write_is_mrif_q;
 
         trans_iova      = '0;
         trans_did       = '0;
@@ -851,6 +884,8 @@ module riscv_iommu #(
                 // AW request received
                 else if (dev_tr_req_i.aw_valid & ~dbg_ongoing_q) begin
                     request_type_n  = WRITE;
+                    write_data_complete_n = 1'b0;
+                    write_is_mrif_n = 1'b0;
                 end
             end
 
@@ -898,17 +933,17 @@ module riscv_iommu #(
             WRITE: begin
                 
                 // Tags
-                trans_iova      =  dev_tr_req_i.aw.addr;
+                trans_iova      =  write_aw_q.addr;
                 // AXI DVM extension for SMMU
-                trans_did       =  dev_tr_req_i.aw.stream_id;
-                trans_pv        =  dev_tr_req_i.aw.ss_id_valid;
-                trans_pid       =  dev_tr_req_i.aw.substream_id;
+                trans_did       =  write_did_q;
+                trans_pv        =  write_pv_q;
+                trans_pid       =  write_pid_q;
                 trans_type      =  rv_iommu::UNTRANSLATED_W;
-                trans_priv      =  dev_tr_req_i.aw.prot[0];
+                trans_priv      =  write_aw_q.prot[0];
 
-                burst_type      =  dev_tr_req_i.aw.burst;
-                burst_length    =  dev_tr_req_i.aw.len;
-                n_bytes         =  dev_tr_req_i.aw.size;
+                burst_type      =  write_aw_q.burst;
+                burst_length    =  write_aw_q.len;
+                n_bytes         =  write_aw_q.size;
                     
                 // Successful translation. Connect AXI demux to Comp IF
                 if (trans_valid) begin
@@ -930,8 +965,29 @@ module riscv_iommu #(
 
                 // We need to wait for AWREADY to go high
                 if (dev_tr_resp_o.aw_ready) begin
-                    request_type_n      = IDLE;
+                    request_type_n      = WRITE_DATA;
                     resume_aw_n         = 1'b0;
+                    write_is_mrif_n     = (demux_aw_select_q == 2'b10);
+                end
+            end
+
+            WRITE_DATA: begin
+                // Retain the translated MRIF lookup context until the handler
+                // has consumed the captured W beat. Other writes wait only for
+                // their W handshake before the next translation may start.
+                trans_iova      = write_aw_q.addr;
+                trans_did       = write_did_q;
+                trans_pv        = write_pv_q;
+                trans_pid       = write_pid_q;
+                trans_type      = rv_iommu::UNTRANSLATED_W;
+                trans_priv      = write_aw_q.prot[0];
+                burst_type      = write_aw_q.burst;
+                burst_length    = write_aw_q.len;
+                n_bytes         = write_aw_q.size;
+
+                if (write_data_complete_n &&
+                    (!write_is_mrif_q || !mrif_handler_expected || mrif_data_consumed)) begin
+                    request_type_n = IDLE;
                 end
             end
 
@@ -947,6 +1003,14 @@ module riscv_iommu #(
             demux_aw_select_q   <= '0;
             demux_ar_select_q   <= '0;
             request_type_q      <= IDLE;
+            write_aw_q          <= '0;
+            write_data_q        <= '0;
+            write_did_q         <= '0;
+            write_pv_q          <= 1'b0;
+            write_pid_q         <= '0;
+            write_data_valid_q  <= 1'b0;
+            write_data_complete_q <= 1'b0;
+            write_is_mrif_q     <= 1'b0;
         end
 
         else begin
@@ -956,6 +1020,37 @@ module riscv_iommu #(
             demux_aw_select_q   <= demux_aw_select_n;
             demux_ar_select_q   <= demux_ar_select_n;
             request_type_q      <= request_type_n;
+            write_data_complete_q <= write_data_complete_n;
+            write_is_mrif_q     <= write_is_mrif_n;
+
+            if ((request_type_q == IDLE) && (request_type_n == WRITE)) begin
+                write_aw_q.id     <= dev_tr_req_i.aw.id;
+                write_aw_q.addr   <= dev_tr_req_i.aw.addr;
+                write_aw_q.len    <= dev_tr_req_i.aw.len;
+                write_aw_q.size   <= dev_tr_req_i.aw.size;
+                write_aw_q.burst  <= dev_tr_req_i.aw.burst;
+                write_aw_q.lock   <= dev_tr_req_i.aw.lock;
+                write_aw_q.cache  <= dev_tr_req_i.aw.cache;
+                write_aw_q.prot   <= dev_tr_req_i.aw.prot;
+                write_aw_q.qos    <= dev_tr_req_i.aw.qos;
+                write_aw_q.region <= dev_tr_req_i.aw.region;
+                write_aw_q.atop   <= dev_tr_req_i.aw.atop;
+                write_aw_q.user   <= dev_tr_req_i.aw.user;
+                write_did_q       <= dev_tr_req_i.aw.stream_id;
+                write_pv_q        <= dev_tr_req_i.aw.ss_id_valid;
+                write_pid_q       <= dev_tr_req_i.aw.substream_id;
+            end
+
+            if (!write_data_valid_q && dev_tr_req_i.w_valid &&
+                ((request_type_n == WRITE) || (request_type_q == WRITE) ||
+                 (request_type_q == WRITE_DATA))) begin
+                write_data_q       <= dev_tr_req_i.w;
+                write_data_valid_q <= 1'b1;
+            end
+
+            if ((request_type_q == WRITE_DATA) && (request_type_n == IDLE)) begin
+                write_data_valid_q <= 1'b0;
+            end
         end
     end : transaction_control_seq
 

--- a/rtl/translation_logic/rv_iommu_mrif_handler.sv
+++ b/rtl/translation_logic/rv_iommu_mrif_handler.sv
@@ -47,6 +47,8 @@ module rv_iommu_mrif_handler #(
 
     // Init MRIF processing. MSI data and MRIF cache data are valid.
     input  logic        init_mrif_i,
+    // The handler can capture a new MRIF request.
+    output logic        ready_o,
     // Abort access (discard without fault)
     output logic        ignore_o,
 
@@ -105,6 +107,7 @@ module rv_iommu_mrif_handler #(
 
     assign error_o  = (state_q == ERROR);
     assign cause_o  = rv_iommu::MSI_PT_DATA_CORRUPTION;
+    assign ready_o  = (state_q == IDLE);
 
     always_comb begin : mrif_handler_comb
 

--- a/rtl/translation_logic/wrapper/rv_iommu_translation_wrapper.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_translation_wrapper.sv
@@ -120,6 +120,7 @@ module rv_iommu_translation_wrapper #(
     input  logic [19:0]                 flush_pscid_i,  // PSCID (Guest virtual address space identifier) to tag entries to be flushed
 
     output logic                        ignore_request_o,   // Ignore request (MRIF only)
+    output logic                        mrif_data_consumed_o,// Captured MSI data was accepted by the MRIF handler
     input  logic                        msi_data_valid_i,   // MSI data sent by DMA available
     input  logic [31:0]                 msi_data_i          // MSI data
 );
@@ -205,6 +206,7 @@ module rv_iommu_translation_wrapper #(
                 .flush_pscid_i,         // PSCID (Guest virtual address space identifier) to tag entries to be flushed
             
                 .ignore_request_o,      // Ignore request (MRIF only)
+                .mrif_data_consumed_o,  // Captured MSI data accepted
                 .msi_data_valid_i,      // MSI data sent by DMA available
                 .msi_data_i             // MSI data
             );
@@ -281,6 +283,7 @@ module rv_iommu_translation_wrapper #(
                 .flush_pscid_i,         // PSCID (Guest virtual address space identifier) to tag entries to be flushed
             
                 .ignore_request_o,      // Ignore request (MRIF only)
+                .mrif_data_consumed_o,  // Captured MSI data accepted
                 .msi_data_valid_i,      // MSI data sent by DMA available
                 .msi_data_i             // MSI data
             );

--- a/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4.sv
@@ -115,6 +115,7 @@ module rv_iommu_tw_sv39x4 #(
     input  logic [19:0]                 flush_pscid_i,   // PSCID (Guest virtual address space identifier) to tag entries to be flushed
 
     output logic        ignore_request_o,   // Ignore request (MRIF only)
+    output logic        mrif_data_consumed_o,// Captured MSI data was accepted by the MRIF handler
     input  logic        msi_data_valid_i,   // MSI data sent by DMA available
     input  logic [31:0] msi_data_i          // MSI data
 );
@@ -571,6 +572,9 @@ module rv_iommu_tw_sv39x4 #(
 
     // MRIF Support enabled
     if (MSITrans == rv_iommu::MSI_FLAT_MRIF) begin : gen_mrif_support
+        logic mrif_handler_ready;
+
+        assign mrif_data_consumed_o = mrifc_lu_hit & msi_data_valid_i & mrif_handler_ready;
         
         //# MRIF Handler
         rv_iommu_mrif_handler #(
@@ -585,7 +589,8 @@ module rv_iommu_tw_sv39x4 #(
             .mem_req_o      (mrif_handler_axi_req_o),
 
             // Init MRIF processing. MSI data and MRIF cache data are valid.
-            .init_mrif_i    (mrifc_lu_hit & msi_data_valid_i),
+            .init_mrif_i    (mrif_data_consumed_o),
+            .ready_o        (mrif_handler_ready),
             // Abort access (discard without fault)
             .ignore_o       (mrif_handler_ignore),
 
@@ -647,6 +652,7 @@ module rv_iommu_tw_sv39x4 #(
     else begin : gen_mrif_support_disabled
         
         assign mrif_handler_axi_req_o   = '0;
+        assign mrif_data_consumed_o     = 1'b0;
 
         assign mrif_handler_ignore      = 1'b0;
 

--- a/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4_pc.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4_pc.sv
@@ -122,6 +122,7 @@ module rv_iommu_tw_sv39x4_pc #(
     input  logic [19:0]                 flush_pscid_i,  // PSCID to tag entries to be flushed
 
     output logic        ignore_request_o,   // Ignore request (MRIF only)
+    output logic        mrif_data_consumed_o,// Captured MSI data was accepted by the MRIF handler
     input  logic        msi_data_valid_i,   // MSI data sent by DMA available
     input  logic [31:0] msi_data_i          // MSI data
 );
@@ -357,7 +358,7 @@ module rv_iommu_tw_sv39x4_pc #(
 
     // Resume and ignore the current translation (used for MRIF processing)
     logic   msiptw_ignore, mrif_handler_ignore;
-    assign  ignore_request_o = (msiptw_ignore | mrif_handler_ignore);
+    assign  ignore_request_o = (msiptw_ignore | mrif_handler_ignore | mrifc_lu_hit);
 
     //# Device Directory Table Cache
     rv_iommu_ddtc #(
@@ -649,6 +650,9 @@ module rv_iommu_tw_sv39x4_pc #(
 
     // MRIF Support enabled
     if (MSITrans == rv_iommu::MSI_FLAT_MRIF) begin : gen_mrif_support
+        logic mrif_handler_ready;
+
+        assign mrif_data_consumed_o = mrifc_lu_hit & msi_data_valid_i & mrif_handler_ready;
         
         //# MRIF Handler
         rv_iommu_mrif_handler #(
@@ -663,7 +667,8 @@ module rv_iommu_tw_sv39x4_pc #(
             .mem_req_o      (mrif_handler_axi_req_o),
 
             // Init MRIF processing. MSI data and MRIF cache data are valid
-            .init_mrif_i    (mrifc_lu_hit & msi_data_valid_i),
+            .init_mrif_i    (mrif_data_consumed_o),
+            .ready_o        (mrif_handler_ready),
             // Abort access (discard without fault)
             .ignore_o       (mrif_handler_ignore),
 
@@ -725,6 +730,7 @@ module rv_iommu_tw_sv39x4_pc #(
     else begin : gen_mrif_support_disabled
         
         assign mrif_handler_axi_req_o   = '0;
+        assign mrif_data_consumed_o     = 1'b0;
 
         assign mrif_handler_ignore      = 1'b0;
 


### PR DESCRIPTION
## Summary

Capture the active AXI write across the independent AW/W channels before MRIF processing. Keep translation context live through the final W beat, then retire an MRIF write only after the handler accepts the captured interrupt identity.

Also route process-context MRIF cache hits through the ignore slave, matching the non-process-context wrapper.

## Rationale

The top-level request controller previously returned to idle when AW retired while the MRIF handler consumed the instantaneous external `WVALID` and `WDATA`. A legal delayed W beat was therefore accepted after the translation context disappeared, losing the MSI side effect. Adding only the process-context ignore route retired the request but exposed the same loss.

The old process-context route also left a cache-hit AW disconnected from every completion path. Held WVALID could repeatedly start the handler while AW remained stalled.

## Validation

- Verilator 5.046 lint.
- Complete-top MRIF cache fill through the real DDT/MSI page-table path.
- Simultaneous AW/W, AW-before-W and W-before-AW.
- Exactly one pending update plus one notice per accepted valid MSI.
- Both `InclPC=0` and `InclPC=1`.

```text
MRIF_NATURAL_SPLIT_AW_W aw_retired=1 ip_stores=1
MRIF_NATURAL_W_BEFORE_AW aw_retired=1 ip_stores=1
PC_MRIF_NATURAL cache_update=1 cache_hit=1 ip_stores=1 notices=1 aw_retired=1 w_retired=1 expected_retire=1 request_type=0
```

## Follow-ups

PR #46 is stacked on this capture boundary for strict doorbell validation. PR #48 is stacked after #46 for notice semantics.