### PR TITLE
mrif_handler: emit the required notice for every valid MRIF MSI

### DIFF
--- a/rtl/riscv_iommu.sv
+++ b/rtl/riscv_iommu.sv
@@ -277,11 +277,14 @@ module riscv_iommu #(
     assign axi_aux_req.w_valid      = dev_tr_req_i.w_valid;
     assign write_data_handshake     = dev_tr_req_i.w_valid & dev_tr_resp_o.w_ready;
 
-    // These are the validity checks already implemented by the upstream MRIF
-    // path. The follow-up encoding patch extends this predicate with the AXI
-    // size and byte-lane requirements.
-    assign mrif_handler_expected    = (write_aw_q.addr[11:0] == '0) &
-                                      !(|write_data_q.data[31:11]);
+    // Unsupported MRIF-page writes retire through the ignore slave without
+    // changing interrupt state.
+    assign mrif_handler_expected = (write_aw_q.addr[11:0] == '0) &
+                                   (write_aw_q.len == '0) &
+                                   (write_aw_q.size == 3'b010) &
+                                   (write_data_q.strb == {{(DATA_WIDTH/8-4){1'b0}}, 4'hf}) &
+                                   write_data_q.last &
+                                   !(|write_data_q.data[31:11]);
 
     // B
     assign axi_aux_req.b_ready      = dev_tr_req_i.b_ready;

--- a/rtl/riscv_iommu.sv
+++ b/rtl/riscv_iommu.sv
@@ -110,8 +110,25 @@ module riscv_iommu #(
     enum logic [1:0] {
         IDLE,
         READ,
-        WRITE
+        WRITE,
+        WRITE_DATA
     } request_type_q, request_type_n;
+
+    // The translation request interface processes one write at a time. Keep
+    // its address metadata and data beat until both independent AXI channels
+    // have completed. MRIF handling may consume the data after AW has retired.
+    aw_chan_t                      write_aw_q;
+    w_chan_t                       write_data_q;
+    logic [23:0]                   write_did_q;
+    logic                          write_pv_q;
+    logic [19:0]                   write_pid_q;
+    logic                          write_data_valid_q;
+    logic                          write_data_complete_q, write_data_complete_n;
+    logic                          write_is_mrif_q, write_is_mrif_n;
+    logic                          write_data_handshake;
+    logic                          mrif_handler_expected;
+    logic                          mrif_data_consumed;
+    logic                          translation_request_active;
 
     // Transaction parameters
     // Final parameters. Selected between AR/AW requests and DBG IF requests
@@ -242,22 +259,29 @@ module riscv_iommu #(
     // AW
     assign axi_aux_req.aw_valid     = resume_aw_q;
 
-    assign axi_aux_req.aw.id        = dev_tr_req_i.aw.id;
+    assign axi_aux_req.aw.id        = write_aw_q.id;
     assign axi_aux_req.aw.addr      = {{riscv::XLEN-riscv::PLEN{1'b0}}, spaddr};    // translated address
-    assign axi_aux_req.aw.len       = dev_tr_req_i.aw.len;
-    assign axi_aux_req.aw.size      = dev_tr_req_i.aw.size;
-    assign axi_aux_req.aw.burst     = dev_tr_req_i.aw.burst;
-    assign axi_aux_req.aw.lock      = dev_tr_req_i.aw.lock;
-    assign axi_aux_req.aw.cache     = dev_tr_req_i.aw.cache;
-    assign axi_aux_req.aw.prot      = dev_tr_req_i.aw.prot;
-    assign axi_aux_req.aw.qos       = dev_tr_req_i.aw.qos;
-    assign axi_aux_req.aw.region    = dev_tr_req_i.aw.region;
-    assign axi_aux_req.aw.atop      = dev_tr_req_i.aw.atop;
-    assign axi_aux_req.aw.user      = dev_tr_req_i.aw.user;
+    assign axi_aux_req.aw.len       = write_aw_q.len;
+    assign axi_aux_req.aw.size      = write_aw_q.size;
+    assign axi_aux_req.aw.burst     = write_aw_q.burst;
+    assign axi_aux_req.aw.lock      = write_aw_q.lock;
+    assign axi_aux_req.aw.cache     = write_aw_q.cache;
+    assign axi_aux_req.aw.prot      = write_aw_q.prot;
+    assign axi_aux_req.aw.qos       = write_aw_q.qos;
+    assign axi_aux_req.aw.region    = write_aw_q.region;
+    assign axi_aux_req.aw.atop      = write_aw_q.atop;
+    assign axi_aux_req.aw.user      = write_aw_q.user;
 
     // W
     assign axi_aux_req.w            = dev_tr_req_i.w;
     assign axi_aux_req.w_valid      = dev_tr_req_i.w_valid;
+    assign write_data_handshake     = dev_tr_req_i.w_valid & dev_tr_resp_o.w_ready;
+
+    // These are the validity checks already implemented by the upstream MRIF
+    // path. The follow-up encoding patch extends this predicate with the AXI
+    // size and byte-lane requirements.
+    assign mrif_handler_expected    = (write_aw_q.addr[11:0] == '0) &
+                                      !(|write_data_q.data[31:11]);
 
     // B
     assign axi_aux_req.b_ready      = dev_tr_req_i.b_ready;
@@ -564,8 +588,10 @@ module riscv_iommu #(
 
         // MRIF Control
         .ignore_request_o   (ignore_request             ),  // Ignore AXI request, as the transaction was to an MRIF
-        .msi_data_valid_i   (dev_tr_req_i.w_valid       ),  // Data present in AWDATA is valid (for MRIF purposes)
-        .msi_data_i         (dev_tr_req_i.w.data[31:0]  )   // MSI data
+        .mrif_data_consumed_o(mrif_data_consumed        ),
+        .msi_data_valid_i   ((request_type_q == WRITE_DATA) & write_is_mrif_q &
+                             write_data_valid_q & mrif_handler_expected),
+        .msi_data_i         (write_data_q.data[31:0]    )   // Captured MSI data
     );
 
     //# Software Interface Wrapper
@@ -664,6 +690,10 @@ module riscv_iommu #(
     );
 
     //# Boundary Check
+    assign translation_request_active = (request_type_q == READ) |
+                                        (request_type_q == WRITE) |
+                                        ((request_type_q == WRITE_DATA) & write_is_mrif_q);
+
     // In order to send error response, we need to set the corresponding valid signal and select the error slave in the AXI Demux.
     // To do that, we may OR the translation error flag from the translation wrapper with another flag to indicate a 4kiB cross
     // and trigger the error response
@@ -673,7 +703,7 @@ module riscv_iommu #(
         rv_iommu_axi4_bc i_rv_iommu_axi4_bc
         (
             // AxVALID
-            .request_i          (request_type_q != IDLE),
+            .request_i          (translation_request_active),
             // AxADDR
             .addr_i             ( trans_iova            ),
             // AxBURST
@@ -693,7 +723,7 @@ module riscv_iommu #(
     // In this scenario, there's no need to include this logic.
     else begin : gen_axi4_bc_disabled
 
-        assign request_ongoing   = (request_type_q != IDLE);
+        assign request_ongoing = translation_request_active;
         assign bound_violation = 1'b0;
     end : gen_axi4_bc_disabled
     endgenerate
@@ -828,6 +858,9 @@ module riscv_iommu #(
         demux_ar_select_n   = demux_ar_select_q;
         resume_aw_n         = resume_aw_q;
         resume_ar_n         = resume_ar_q;
+        write_data_complete_n = write_data_complete_q |
+                                (write_data_handshake & dev_tr_req_i.w.last);
+        write_is_mrif_n       = write_is_mrif_q;
 
         trans_iova      = '0;
         trans_did       = '0;
@@ -851,6 +884,8 @@ module riscv_iommu #(
                 // AW request received
                 else if (dev_tr_req_i.aw_valid & ~dbg_ongoing_q) begin
                     request_type_n  = WRITE;
+                    write_data_complete_n = 1'b0;
+                    write_is_mrif_n = 1'b0;
                 end
             end
 
@@ -898,17 +933,17 @@ module riscv_iommu #(
             WRITE: begin
                 
                 // Tags
-                trans_iova      =  dev_tr_req_i.aw.addr;
+                trans_iova      =  write_aw_q.addr;
                 // AXI DVM extension for SMMU
-                trans_did       =  dev_tr_req_i.aw.stream_id;
-                trans_pv        =  dev_tr_req_i.aw.ss_id_valid;
-                trans_pid       =  dev_tr_req_i.aw.substream_id;
+                trans_did       =  write_did_q;
+                trans_pv        =  write_pv_q;
+                trans_pid       =  write_pid_q;
                 trans_type      =  rv_iommu::UNTRANSLATED_W;
-                trans_priv      =  dev_tr_req_i.aw.prot[0];
+                trans_priv      =  write_aw_q.prot[0];
 
-                burst_type      =  dev_tr_req_i.aw.burst;
-                burst_length    =  dev_tr_req_i.aw.len;
-                n_bytes         =  dev_tr_req_i.aw.size;
+                burst_type      =  write_aw_q.burst;
+                burst_length    =  write_aw_q.len;
+                n_bytes         =  write_aw_q.size;
                     
                 // Successful translation. Connect AXI demux to Comp IF
                 if (trans_valid) begin
@@ -930,8 +965,29 @@ module riscv_iommu #(
 
                 // We need to wait for AWREADY to go high
                 if (dev_tr_resp_o.aw_ready) begin
-                    request_type_n      = IDLE;
+                    request_type_n      = WRITE_DATA;
                     resume_aw_n         = 1'b0;
+                    write_is_mrif_n     = (demux_aw_select_q == 2'b10);
+                end
+            end
+
+            WRITE_DATA: begin
+                // Retain the translated MRIF lookup context until the handler
+                // has consumed the captured W beat. Other writes wait only for
+                // their W handshake before the next translation may start.
+                trans_iova      = write_aw_q.addr;
+                trans_did       = write_did_q;
+                trans_pv        = write_pv_q;
+                trans_pid       = write_pid_q;
+                trans_type      = rv_iommu::UNTRANSLATED_W;
+                trans_priv      = write_aw_q.prot[0];
+                burst_type      = write_aw_q.burst;
+                burst_length    = write_aw_q.len;
+                n_bytes         = write_aw_q.size;
+
+                if (write_data_complete_n &&
+                    (!write_is_mrif_q || !mrif_handler_expected || mrif_data_consumed)) begin
+                    request_type_n = IDLE;
                 end
             end
 
@@ -947,6 +1003,14 @@ module riscv_iommu #(
             demux_aw_select_q   <= '0;
             demux_ar_select_q   <= '0;
             request_type_q      <= IDLE;
+            write_aw_q          <= '0;
+            write_data_q        <= '0;
+            write_did_q         <= '0;
+            write_pv_q          <= 1'b0;
+            write_pid_q         <= '0;
+            write_data_valid_q  <= 1'b0;
+            write_data_complete_q <= 1'b0;
+            write_is_mrif_q     <= 1'b0;
         end
 
         else begin
@@ -956,6 +1020,37 @@ module riscv_iommu #(
             demux_aw_select_q   <= demux_aw_select_n;
             demux_ar_select_q   <= demux_ar_select_n;
             request_type_q      <= request_type_n;
+            write_data_complete_q <= write_data_complete_n;
+            write_is_mrif_q     <= write_is_mrif_n;
+
+            if ((request_type_q == IDLE) && (request_type_n == WRITE)) begin
+                write_aw_q.id     <= dev_tr_req_i.aw.id;
+                write_aw_q.addr   <= dev_tr_req_i.aw.addr;
+                write_aw_q.len    <= dev_tr_req_i.aw.len;
+                write_aw_q.size   <= dev_tr_req_i.aw.size;
+                write_aw_q.burst  <= dev_tr_req_i.aw.burst;
+                write_aw_q.lock   <= dev_tr_req_i.aw.lock;
+                write_aw_q.cache  <= dev_tr_req_i.aw.cache;
+                write_aw_q.prot   <= dev_tr_req_i.aw.prot;
+                write_aw_q.qos    <= dev_tr_req_i.aw.qos;
+                write_aw_q.region <= dev_tr_req_i.aw.region;
+                write_aw_q.atop   <= dev_tr_req_i.aw.atop;
+                write_aw_q.user   <= dev_tr_req_i.aw.user;
+                write_did_q       <= dev_tr_req_i.aw.stream_id;
+                write_pv_q        <= dev_tr_req_i.aw.ss_id_valid;
+                write_pid_q       <= dev_tr_req_i.aw.substream_id;
+            end
+
+            if (!write_data_valid_q && dev_tr_req_i.w_valid &&
+                ((request_type_n == WRITE) || (request_type_q == WRITE) ||
+                 (request_type_q == WRITE_DATA))) begin
+                write_data_q       <= dev_tr_req_i.w;
+                write_data_valid_q <= 1'b1;
+            end
+
+            if ((request_type_q == WRITE_DATA) && (request_type_n == IDLE)) begin
+                write_data_valid_q <= 1'b0;
+            end
         end
     end : transaction_control_seq
 

--- a/rtl/translation_logic/rv_iommu_mrif_handler.sv
+++ b/rtl/translation_logic/rv_iommu_mrif_handler.sv
@@ -13,22 +13,14 @@
 // Author:  Manuel Rodríguez <manuel.cederog@gmail.com>
 // Date:    09/12/2023
 //
-// Description: Handler for MSI translations in MRIF mode
-//              Modifies the destination MRIF using read-modify-write operations.
-//              Sends a notice MSI using the data provided by the MSI PTE if the IE bit 
-//                  corresponding to the interrupt identity being processed is set.
+// Description: Handler for MSI translations in MRIF mode.
+//              Sets the destination MRIF pending bit and sends a notice MSI
+//              for every valid MRIF-mode MSI, regardless of the IE bit.
 //
 
 /*
-    -   This module receives the interrupt identity and the base address of the destination MRIF.
-        It computes the address of the IP and IE bits corresponding to the interrupt identity within the MRIF and fetches both DWs.
-        Then, it sets the corresponding IP bit and checks whether the IE bit is set.
-        Finally, only the IP DW is written back to the MRIF.
-
-    -   If the IE bit was NOT set, the processing ends here, as there is no need to send the 
-            notice MSI because the corresponding interrupt is not enabled.
-
-    -   Otherwise, if the IE bit was set, a notice MSI is sent using the input NID and NPPN.
+    -   This module fetches the IP and IE DWs for the interrupt identity.
+    -   It sets IP when needed, then sends the notice MSI using NID and NPPN.
 */
 
 module rv_iommu_mrif_handler #(
@@ -89,8 +81,6 @@ module rv_iommu_mrif_handler #(
 
     // MRIF IP register
     logic [63:0] mrif_ip_q, mrif_ip_n;
-    // MRIF IE register
-    logic [63:0] mrif_ie_q, mrif_ie_n;
     // Interrupt ID register
     logic [10:0] int_id_q, int_id_n;
     // Notice PPN register
@@ -168,7 +158,6 @@ module rv_iommu_mrif_handler #(
         wr_state_n      = wr_state_q;
         wait_rlast_n    = wait_rlast_q;
         mrif_ip_n       = mrif_ip_q;
-        mrif_ie_n       = mrif_ie_q;
         int_id_n        = int_id_q;
         notice_ppn_n    = notice_ppn_q;
         notice_nid_n    = notice_nid_q;
@@ -219,23 +208,11 @@ module rv_iommu_mrif_handler #(
                     // Second DW: IE
                     if (mem_resp_i.r.last) begin
 
-                        // Save IE DW
-                        mrif_ie_n   = mem_resp_i.r.data;
-
                         // If the IP bit corresponding to the interrupt ID is already set, there is no need to write back the IP DW to the MRIF
                         if (|(mrif_ip_q & int_id_bit)) begin
-                            
-                            // If the IE bit corresponding to the interrupt ID is not set, there is no need to send the MSI notice
-                            // IE bit set. Send MSI notice
-                            if (|(mem_resp_i.r.data & int_id_bit)) begin
-                                state_n     = WRITE_NOTICE;
-                                wr_state_n  = AW_REQ;
-                            end
-
-                            // IE bit clear. Go back to IDLE
-                            else begin
-                                state_n = IDLE;
-                            end
+                            // Always send the notice MSI (AIA), even if already pending.
+                            state_n     = WRITE_NOTICE;
+                            wr_state_n  = AW_REQ;
                         end
 
                         // IP bit is not set, write back the IP DW
@@ -260,7 +237,6 @@ module rv_iommu_mrif_handler #(
             end
 
             // Write back the IP DW to the MRIF.
-            // Check whether the corresponding IE bit is enable
             WRITE_MRIF: begin
 
                 case (wr_state_q)
@@ -294,8 +270,8 @@ module rv_iommu_mrif_handler #(
                             mem_req_o.b_ready   = 1'b1;
                             wr_state_n  = AW_REQ;
 
-                            // Check IE bit to determine whether to send notice MSI
-                            state_n = (|(mrif_ie_q & int_id_bit)) ? (WRITE_NOTICE) : (IDLE);
+                            // Always send the notice MSI (AIA), regardless of IE.
+                            state_n = WRITE_NOTICE;
 
                             // AXI error
                             if (mem_resp_i.b.resp != axi_pkg::RESP_OKAY) begin
@@ -308,8 +284,7 @@ module rv_iommu_mrif_handler #(
                 endcase
             end
 
-            // If the IE bit corresponding to the given interrupt identity was set,
-            //  send MSI notice using input NID and NPPN.
+            // Send the notice MSI using input NID and NPPN.
             WRITE_NOTICE: begin
                 
                 case (wr_state_q)
@@ -384,7 +359,6 @@ module rv_iommu_mrif_handler #(
             pptr_q          <= '0;
             wait_rlast_q    <= 1'b0;
             mrif_ip_q       <= '0;
-            mrif_ie_q       <= '0;
             int_id_q        <= '0;
             notice_ppn_q    <= '0;
             notice_nid_q    <= '0;
@@ -397,7 +371,6 @@ module rv_iommu_mrif_handler #(
             pptr_q          <= pptr_n;
             wait_rlast_q    <= wait_rlast_n;
             mrif_ip_q       <= mrif_ip_n;
-            mrif_ie_q       <= mrif_ie_n;
             int_id_q        <= int_id_n;
             notice_ppn_q    <= notice_ppn_n;
             notice_nid_q    <= notice_nid_n;

--- a/rtl/translation_logic/rv_iommu_mrif_handler.sv
+++ b/rtl/translation_logic/rv_iommu_mrif_handler.sv
@@ -47,6 +47,8 @@ module rv_iommu_mrif_handler #(
 
     // Init MRIF processing. MSI data and MRIF cache data are valid.
     input  logic        init_mrif_i,
+    // The handler can capture a new MRIF request.
+    output logic        ready_o,
     // Abort access (discard without fault)
     output logic        ignore_o,
 
@@ -105,6 +107,7 @@ module rv_iommu_mrif_handler #(
 
     assign error_o  = (state_q == ERROR);
     assign cause_o  = rv_iommu::MSI_PT_DATA_CORRUPTION;
+    assign ready_o  = (state_q == IDLE);
 
     always_comb begin : mrif_handler_comb
 

--- a/rtl/translation_logic/wrapper/rv_iommu_translation_wrapper.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_translation_wrapper.sv
@@ -120,6 +120,7 @@ module rv_iommu_translation_wrapper #(
     input  logic [19:0]                 flush_pscid_i,  // PSCID (Guest virtual address space identifier) to tag entries to be flushed
 
     output logic                        ignore_request_o,   // Ignore request (MRIF only)
+    output logic                        mrif_data_consumed_o,// Captured MSI data was accepted by the MRIF handler
     input  logic                        msi_data_valid_i,   // MSI data sent by DMA available
     input  logic [31:0]                 msi_data_i          // MSI data
 );
@@ -205,6 +206,7 @@ module rv_iommu_translation_wrapper #(
                 .flush_pscid_i,         // PSCID (Guest virtual address space identifier) to tag entries to be flushed
             
                 .ignore_request_o,      // Ignore request (MRIF only)
+                .mrif_data_consumed_o,  // Captured MSI data accepted
                 .msi_data_valid_i,      // MSI data sent by DMA available
                 .msi_data_i             // MSI data
             );
@@ -281,6 +283,7 @@ module rv_iommu_translation_wrapper #(
                 .flush_pscid_i,         // PSCID (Guest virtual address space identifier) to tag entries to be flushed
             
                 .ignore_request_o,      // Ignore request (MRIF only)
+                .mrif_data_consumed_o,  // Captured MSI data accepted
                 .msi_data_valid_i,      // MSI data sent by DMA available
                 .msi_data_i             // MSI data
             );

--- a/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4.sv
@@ -115,6 +115,7 @@ module rv_iommu_tw_sv39x4 #(
     input  logic [19:0]                 flush_pscid_i,   // PSCID (Guest virtual address space identifier) to tag entries to be flushed
 
     output logic        ignore_request_o,   // Ignore request (MRIF only)
+    output logic        mrif_data_consumed_o,// Captured MSI data was accepted by the MRIF handler
     input  logic        msi_data_valid_i,   // MSI data sent by DMA available
     input  logic [31:0] msi_data_i          // MSI data
 );
@@ -571,6 +572,9 @@ module rv_iommu_tw_sv39x4 #(
 
     // MRIF Support enabled
     if (MSITrans == rv_iommu::MSI_FLAT_MRIF) begin : gen_mrif_support
+        logic mrif_handler_ready;
+
+        assign mrif_data_consumed_o = mrifc_lu_hit & msi_data_valid_i & mrif_handler_ready;
         
         //# MRIF Handler
         rv_iommu_mrif_handler #(
@@ -585,7 +589,8 @@ module rv_iommu_tw_sv39x4 #(
             .mem_req_o      (mrif_handler_axi_req_o),
 
             // Init MRIF processing. MSI data and MRIF cache data are valid.
-            .init_mrif_i    (mrifc_lu_hit & msi_data_valid_i),
+            .init_mrif_i    (mrif_data_consumed_o),
+            .ready_o        (mrif_handler_ready),
             // Abort access (discard without fault)
             .ignore_o       (mrif_handler_ignore),
 
@@ -647,6 +652,7 @@ module rv_iommu_tw_sv39x4 #(
     else begin : gen_mrif_support_disabled
         
         assign mrif_handler_axi_req_o   = '0;
+        assign mrif_data_consumed_o     = 1'b0;
 
         assign mrif_handler_ignore      = 1'b0;
 

--- a/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4_pc.sv
+++ b/rtl/translation_logic/wrapper/rv_iommu_tw_sv39x4_pc.sv
@@ -122,6 +122,7 @@ module rv_iommu_tw_sv39x4_pc #(
     input  logic [19:0]                 flush_pscid_i,  // PSCID to tag entries to be flushed
 
     output logic        ignore_request_o,   // Ignore request (MRIF only)
+    output logic        mrif_data_consumed_o,// Captured MSI data was accepted by the MRIF handler
     input  logic        msi_data_valid_i,   // MSI data sent by DMA available
     input  logic [31:0] msi_data_i          // MSI data
 );
@@ -357,7 +358,7 @@ module rv_iommu_tw_sv39x4_pc #(
 
     // Resume and ignore the current translation (used for MRIF processing)
     logic   msiptw_ignore, mrif_handler_ignore;
-    assign  ignore_request_o = (msiptw_ignore | mrif_handler_ignore);
+    assign  ignore_request_o = (msiptw_ignore | mrif_handler_ignore | mrifc_lu_hit);
 
     //# Device Directory Table Cache
     rv_iommu_ddtc #(
@@ -649,6 +650,9 @@ module rv_iommu_tw_sv39x4_pc #(
 
     // MRIF Support enabled
     if (MSITrans == rv_iommu::MSI_FLAT_MRIF) begin : gen_mrif_support
+        logic mrif_handler_ready;
+
+        assign mrif_data_consumed_o = mrifc_lu_hit & msi_data_valid_i & mrif_handler_ready;
         
         //# MRIF Handler
         rv_iommu_mrif_handler #(
@@ -663,7 +667,8 @@ module rv_iommu_tw_sv39x4_pc #(
             .mem_req_o      (mrif_handler_axi_req_o),
 
             // Init MRIF processing. MSI data and MRIF cache data are valid
-            .init_mrif_i    (mrifc_lu_hit & msi_data_valid_i),
+            .init_mrif_i    (mrif_data_consumed_o),
+            .ready_o        (mrif_handler_ready),
             // Abort access (discard without fault)
             .ignore_o       (mrif_handler_ignore),
 
@@ -725,6 +730,7 @@ module rv_iommu_tw_sv39x4_pc #(
     else begin : gen_mrif_support_disabled
         
         assign mrif_handler_axi_req_o   = '0;
+        assign mrif_data_consumed_o     = 1'b0;
 
         assign mrif_handler_ignore      = 1'b0;
 


### PR DESCRIPTION
## Summary

Emit the configured notice MSI for every valid MRIF-mode MSI, independently of the destination MRIF IE bit. Remove the stale latched IE state and its IE-gated control flow.

## Rationale

The handler previously changed pending state with IE clear but suppressed the notice. The hypervisor could therefore remain unaware of a valid virtual interrupt update.

## Validation

- Verilator 5.046 lint.
- Focused IE truth-table regression.
- Complete-top MRIF run with naturally populated cache state.
- IE-clear path produces one pending update plus one notice.
- Valid delayed-W and process-context paths remain single-shot.
- Malformed writes from #46 remain side-effect free.

```text
MRIF_NOTICE_IE0=1 MRIF_NOTICE_IE1_CONTROL=1
MRIF_NATURAL_NOTICE_IE0 ip_stores=1 notices=1
```

## Stack

This PR is based on #46, which is based on #45. The notice-only diff will remain after those prerequisites merge.