### PR TITLE
riscv_iommu: order accepted traffic before DDTP Off

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Master interface used to forward permitted requests to the system interconnect. 
 
 On an error, the AXI demux connects the translation request IF to a [PULP AXI Error Slave](https://github.com/pulp-platform/axi/blob/master/src/axi_err_slv.sv), which responds the failing request with an AXI error.
 
+### **DDTP Off Synchronization Interface**
+
+The IOMMU holds `ddtp_sync_req_o` high while a DDTP Off transition is waiting for prior device traffic to reach the platform's global ordering point. The integrator must assert `ddtp_sync_done_i` only after every earlier processed request is observable by all harts, devices and IOMMUs. New translation requests remain stalled until synchronization completes; tying `ddtp_sync_done_i` high is valid only when completion responses already provide this guarantee.
+
 ### **Interrupt wires**
 
 The IOMMU may be configured to generate interrupts as WSIs to request service from software. For this purpose, a set of external wires is driven by the WSI interrupt generation support module, and should be connected to a Platform-Level Interrupt Controller (e.g. PLIC/APLIC). The number of interrupt wires is defined by the N_INT_VEC parameter.

--- a/lint_checks.sv
+++ b/lint_checks.sv
@@ -50,6 +50,10 @@ import rv_iommu::*;
 	input  req_slv_t    			prog_req_i,
 	output resp_slv_t   			prog_resp_o,
 
+	// Global-observability synchronization for DDTP Off
+	output logic                    ddtp_sync_req_o,
+	input  logic                    ddtp_sync_done_i,
+
 	output logic [NumIRQWires-1:0]	wsi_wires_o
 );
 
@@ -112,6 +116,9 @@ import rv_iommu::*;
 		// Programming Interface (Slave)
 		.prog_req_i			( prog_req_i		),
 		.prog_resp_o		( prog_resp_o		),
+
+		.ddtp_sync_req_o	( ddtp_sync_req_o	),
+		.ddtp_sync_done_i	( ddtp_sync_done_i	),
 
 		.wsi_wires_o		( wsi_wires_o		)
 	);

--- a/rtl/riscv_iommu.sv
+++ b/rtl/riscv_iommu.sv
@@ -96,6 +96,10 @@ module riscv_iommu #(
     input  axi_req_slv_t    prog_req_i,
     output axi_rsp_slv_t    prog_resp_o,
 
+    // Global-observability synchronization for DDTP Off
+    output logic            ddtp_sync_req_o,
+    input  logic            ddtp_sync_done_i,
+
     output logic [(N_INT_VEC-1):0] wsi_wires_o
 );
 
@@ -189,6 +193,7 @@ module riscv_iommu #(
     rv_iommu_reg_pkg::iommu_reg2hw_capabilities_reg_t   capabilities;
     rv_iommu_reg_pkg::iommu_reg2hw_fctl_reg_t           fctl;
     rv_iommu_reg_pkg::iommu_reg2hw_ddtp_reg_t           ddtp;
+    logic                                               ddtp_off_pending;
 
     // Debug Interface register wires
     rv_iommu_reg_pkg::iommu_reg2hw_tr_req_iova_reg_t    dbg_if_iova;
@@ -238,6 +243,16 @@ module riscv_iommu #(
     logic   resume_aw_n, resume_aw_q;
     logic   resume_ar_n, resume_ar_q;
 
+    // Keep DDTP busy until every accepted device transaction has returned its
+    // final response. The demux allows MaxTrans transactions for every AXI ID.
+    localparam int unsigned AXI_MAX_TRANS = 8;
+    localparam int unsigned OUTSTANDING_WIDTH = ID_WIDTH + $clog2(AXI_MAX_TRANS + 1);
+    logic [OUTSTANDING_WIDTH-1:0] write_outstanding_n, write_outstanding_q;
+    logic [OUTSTANDING_WIDTH-1:0] read_outstanding_n, read_outstanding_q;
+    logic                         write_accept, write_complete;
+    logic                         read_accept, read_complete;
+    logic                         completion_in_flight;
+
     // Connect the aux AXI bus to the translation request interface
     // AW
     assign axi_aux_req.aw_valid     = resume_aw_q;
@@ -280,6 +295,44 @@ module riscv_iommu #(
     // R
     assign axi_aux_req.r_ready      = dev_tr_req_i.r_ready;
 
+    assign write_accept   = axi_aux_req.aw_valid && dev_tr_resp_o.aw_ready;
+    assign write_complete = dev_tr_resp_o.b_valid && axi_aux_req.b_ready;
+    assign read_accept    = (axi_aux_req.ar_valid && dev_tr_resp_o.ar_ready) ||
+                            (write_accept && axi_aux_req.aw.atop[5]);
+    assign read_complete  = dev_tr_resp_o.r_valid && axi_aux_req.r_ready &&
+                            dev_tr_resp_o.r.last;
+
+    // Include current-cycle accepts to close the gap before the counters update.
+    assign completion_in_flight = (|write_outstanding_q) || (|read_outstanding_q) ||
+                                  write_accept || read_accept;
+
+    always_comb begin : outstanding_count_comb
+        write_outstanding_n = write_outstanding_q;
+        read_outstanding_n  = read_outstanding_q;
+
+        case ({write_accept, write_complete})
+            2'b10: write_outstanding_n = write_outstanding_q + 1'b1;
+            2'b01: write_outstanding_n = write_outstanding_q - 1'b1;
+            default: ;
+        endcase
+
+        case ({read_accept, read_complete})
+            2'b10: read_outstanding_n = read_outstanding_q + 1'b1;
+            2'b01: read_outstanding_n = read_outstanding_q - 1'b1;
+            default: ;
+        endcase
+    end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin : outstanding_count_seq
+        if (~rst_ni) begin
+            write_outstanding_q <= '0;
+            read_outstanding_q  <= '0;
+        end else begin
+            write_outstanding_q <= write_outstanding_n;
+            read_outstanding_q  <= read_outstanding_n;
+        end
+    end
+
     // Select transaction parameters source: TR request / DBG IF
     // Priority is given to normal translations
     // If a debug translation is ongoing and a normal translation is triggered, we wait for the debug translation to complete.
@@ -312,7 +365,8 @@ module riscv_iommu #(
             dbg_ongoing_n           = dbg_ongoing_q;
 
             // DBG IF request received and no normal translation is starting / ongoing
-            if (dbg_if_ctl.go.q & ~(request_ongoing | dev_tr_req_i.ar_valid | dev_tr_req_i.aw_valid)) begin
+            if (dbg_if_ctl.go.q & ~(request_ongoing | dev_tr_req_i.ar_valid |
+                                    dev_tr_req_i.aw_valid | ddtp_off_pending)) begin
 
                 // Indicate that a debug translation is ongoing
                 dbg_ongoing_n = 1'b1;
@@ -491,7 +545,7 @@ module riscv_iommu #(
         .rst_ni         (rst_ni ),
 
         .req_trans_i    (request_ongoing),                    // Trigger normal translation (if no DBG translation is ongoing)
-        .req_dbg_i      (dbg_if_ctl.go.q & ~request_ongoing), // Trigger debug translation  (if no normal translation is ongoing)
+        .req_dbg_i      (dbg_if_ctl.go.q & ~request_ongoing & ~ddtp_off_pending), // Trigger debug translation  (if no normal translation is ongoing)
 
         // Translation request data
         .did_i          (did        ),  // AxMMUSID / DBG IF
@@ -603,6 +657,9 @@ module riscv_iommu #(
         .capabilities_o     (capabilities),
         .fctl_o             (fctl),
         .ddtp_o             (ddtp),
+        .ddtp_off_pending_o (ddtp_off_pending),
+        .ddtp_sync_req_o    (ddtp_sync_req_o),
+        .ddtp_sync_done_i   (ddtp_sync_done_i),
 
         // DBG IF registers
         .dbg_if_iova_o      (dbg_if_iova),
@@ -630,7 +687,9 @@ module riscv_iommu #(
         .flush_pscid_o      (flush_pscid),  // PSCID (Guest virtual address space identifier) to tag entries to be flushed
 
         // Request data
-        .in_flight_i        (request_ongoing | dbg_if_ctl.go.q),    // The IOMMU is currently processing a transaction
+        .in_flight_i        (request_ongoing | dbg_ongoing_q |
+                             (dbg_if_ctl.go.q & ~ddtp_off_pending) |
+                             completion_in_flight), // The IOMMU is currently processing a transaction
         .trans_type_i       (ttype),            // transaction type
         .did_i              (did),              // device_id associated with the transaction
         .pv_i               (pv),               // to indicate if transaction has a valid process_id
@@ -738,6 +797,7 @@ module riscv_iommu #(
             .resp_t         ( axi_rsp_t     ),
             .NoMstPorts     ( 3             ),  // MRIF supports adds ignoring mechanism
             .AxiLookBits    ( ID_WIDTH      ),  // Assuming same value as AXI ID width
+            .MaxTrans       ( AXI_MAX_TRANS ),
             .FallThrough    ( 1'b0          ),
             .SpillAw        ( 1'b0          ),
             .SpillW         ( 1'b0          ),
@@ -779,6 +839,7 @@ module riscv_iommu #(
             .resp_t         ( axi_rsp_t     ),
             .NoMstPorts     ( 2             ),  // MRIF supports adds ignoring mechanism
             .AxiLookBits    ( ID_WIDTH      ),  // Assuming same value as AXI ID width
+            .MaxTrans       ( AXI_MAX_TRANS ),
             .FallThrough    ( 1'b0          ),
             .SpillAw        ( 1'b0          ),
             .SpillW         ( 1'b0          ),
@@ -844,12 +905,12 @@ module riscv_iommu #(
             IDLE: begin
                 
                 // AR request received (this way we are giving priority to read transactions)
-                if (dev_tr_req_i.ar_valid & ~dbg_ongoing_q) begin
+                if (dev_tr_req_i.ar_valid & ~dbg_ongoing_q & ~ddtp_off_pending) begin
                     request_type_n  = READ;
                 end
 
                 // AW request received
-                else if (dev_tr_req_i.aw_valid & ~dbg_ongoing_q) begin
+                else if (dev_tr_req_i.aw_valid & ~dbg_ongoing_q & ~ddtp_off_pending) begin
                     request_type_n  = WRITE;
                 end
             end

--- a/rtl/software_interface/regmap/rv_iommu_regmap.sv
+++ b/rtl/software_interface/regmap/rv_iommu_regmap.sv
@@ -51,8 +51,11 @@ module rv_iommu_regmap #(
   output rv_iommu_reg_pkg::iommu_reg2hw_t 	reg2hw, // Write
   input  rv_iommu_reg_pkg::iommu_hw2reg_t 	hw2reg, // Read
 
-  input  logic devmode_i,   // If 1, explicit error return for unmapped register access
-  input  logic in_flight_i  // The IOMMU is currently processing a translation
+  input  logic devmode_i,          // If 1, explicit error return for unmapped register access
+  input  logic in_flight_i,        // The IOMMU is currently processing a transaction
+  output logic ddtp_off_pending_o, // An Off transition is waiting for quiescence
+  output logic ddtp_sync_req_o,    // Request global ordering of prior traffic
+  input  logic ddtp_sync_done_i    // Prior traffic reached the global ordering point
 );
 
   import rv_iommu_reg_pkg::* ;
@@ -153,6 +156,7 @@ module rv_iommu_regmap #(
   logic [3:0]   ddtp_iommu_mode_n, ddtp_iommu_mode_q;
   logic [21:0]  ddtp_ppn_l_n, ddtp_ppn_l_q;
   logic [21:0]  ddtp_ppn_h_n, ddtp_ppn_h_q;
+  logic         ddtp_second_word_off;
 
   // cqb (low)
   logic [4:0] 	cqb_log2sz_1_qs;
@@ -2777,8 +2781,13 @@ module rv_iommu_regmap #(
   assign fctl_gxl_we = addr_hit[2] & reg_we & !reg_error;
   assign fctl_gxl_wd = reg_wdata[2];
 
-  // Writes to the ddtp register must be committed to both register halves at the same time
-  // and only if the IOMMU has no in-flight transactions
+  // Writes to the ddtp register must be committed to both register halves at the same time.
+  // Off also requires prior traffic to reach the platform's global ordering point.
+  assign ddtp_off_pending_o = write_l_q && write_h_q && (ddtp_iommu_mode_q == 4'h0);
+  assign ddtp_sync_req_o = ddtp_off_pending_o && !in_flight_i;
+  assign ddtp_second_word_off = (addr_hit[4] && (ddtp_iommu_mode_q == 4'h0)) ||
+                                (addr_hit[3] && (reg_wdata[3:0] == 4'h0));
+
   always_comb begin : ddtp_write_comb
 
     ddtp_iommu_mode_we  = 1'b0;
@@ -2799,7 +2808,8 @@ module rv_iommu_regmap #(
 
     // The IOMMU is not processing a transaction and there is data to be written
     // Commit the write
-    if (!in_flight_i && write_h_q && write_l_q) begin
+    if (!in_flight_i && write_h_q && write_l_q &&
+        (!ddtp_off_pending_o || ddtp_sync_done_i)) begin
       write_l_n           = 1'b0;
       write_h_n           = 1'b0;
 
@@ -2830,8 +2840,8 @@ module rv_iommu_regmap #(
       // Second word
       if ((addr_hit[4] && write_l_q) || (addr_hit[3] && write_h_q)) begin
 
-        // Check whether the IOMMU has in-flight transactions
-        if (in_flight_i) begin
+        // Queue writes that need local quiescence or global synchronization.
+        if (in_flight_i || ddtp_second_word_off) begin
           // Wait for all in-flight transactions to finish
           // Set busy bit
           ddtp_busy_de      = 1'b1;

--- a/rtl/software_interface/wrapper/rv_iommu_sw_if_wrapper.sv
+++ b/rtl/software_interface/wrapper/rv_iommu_sw_if_wrapper.sv
@@ -68,6 +68,11 @@ module rv_iommu_sw_if_wrapper #(
     output rv_iommu_reg_pkg::iommu_reg2hw_fctl_reg_t            fctl_o,
     output rv_iommu_reg_pkg::iommu_reg2hw_ddtp_reg_t            ddtp_o,
 
+    // DDTP Off global-observability synchronization
+    output logic ddtp_off_pending_o,
+    output logic ddtp_sync_req_o,
+    input  logic ddtp_sync_done_i,
+
     // Debug register IF
     output rv_iommu_reg_pkg::iommu_reg2hw_tr_req_iova_reg_t     dbg_if_iova_o,
     input  rv_iommu_reg_pkg::iommu_hw2reg_tr_response_reg_t     dbg_if_resp_i,
@@ -270,8 +275,11 @@ module rv_iommu_sw_if_wrapper #(
         .reg2hw         ( reg2hw        ),
         .hw2reg         ( hw2reg        ),
         
-        .devmode_i      ( 1'b0          ),
-        .in_flight_i    ( in_flight_i   )
+        .devmode_i          ( 1'b0               ),
+        .in_flight_i        ( in_flight_i        ),
+        .ddtp_off_pending_o ( ddtp_off_pending_o ),
+        .ddtp_sync_req_o    ( ddtp_sync_req_o    ),
+        .ddtp_sync_done_i   ( ddtp_sync_done_i   )
     );
 
     //# Command Queue


### PR DESCRIPTION
## Summary

Prevent DDTP from committing Off until accepted device traffic is complete at the IOMMU boundary and has reached a platform-defined global ordering point.

The patch:

- Tracks accepted writes through B, accepted reads through RLAST and response-producing atomics through both response channels.
- Stalls new normal and debug translations after an Off transition becomes pending.
- Holds `ddtp_sync_req_o` until the integrator acknowledges global observability with `ddtp_sync_done_i`.
- Keeps DDTP busy until local completion and platform synchronization both finish.

## Rationale

The current busy check observes only the translation controller. A translated AW can leave that controller while the AXI demultiplexer's write-selection FIFO still owns the matching W. Software can then observe DDTP Off, reclaim the translated destination and have a late W overwrite the new owner's data.

An AXI response is not assumed to be the architectural global ordering point. The new synchronization interface makes that platform contract explicit. Integrators may tie `ddtp_sync_done_i` high only when completion responses already guarantee visibility to all harts, devices and IOMMUs.

## Validation

- Verilator 5.046 full-design lint.
- Complete-top AW-withheld-W regression through the real programming interface and AXI demultiplexer.
- Read-response drain control.
- No-outstanding-traffic control.
- Existing complete-top MRIF witness suite.

The repaired regression reports:

```text
DDTP_LATE_MEMORY_COMMIT addr=0000000000008000 value=feedfacecafebeef overwrote_reclaimed=0
DDTP_SOFTWARE_RECLAIM mode=0 addr=0000000000008000 value=1111222233334444
DDTP_OFF_BEFORE_W=0 LATE_W_FORWARDED=1 RECLAIMED_PAGE_OVERWRITTEN=0
DDTP_READ_OFF_COMMITTED=1
DDTP_IDLE_OFF_COMMITTED=1
```

The upstream control reports:

```text
DDTP_SOFTWARE_RECLAIM mode=0 addr=0000000000008000 value=1111222233334444
DDTP_LATE_MEMORY_COMMIT addr=0000000000008000 value=feedfacecafebeef overwrote_reclaimed=1
DDTP_OFF_BEFORE_W=1 LATE_W_FORWARDED=1 RECLAIMED_PAGE_OVERWRITTEN=1
```
